### PR TITLE
Fix bug in no-op shell script

### DIFF
--- a/tgdbinit
+++ b/tgdbinit
@@ -2,7 +2,7 @@ python
 import subprocess as sp
 import os
 
-NULLPROG = "sh -c 'while [ 1 == 1 ]; do sleep 100; done'"
+NULLPROG = "sh -c 'while [ 1 = 1 ]; do sleep 100; done'"
 
 def tmux(*args):
     return sp.check_output(['tmux'] + list(args)).decode('utf8')


### PR DESCRIPTION
Under ubuntu, 'sh' is really 'dash'. Normal Posix shell only supports '=' instead of the Bash '==' as well.
Without this fix, the tmux panes would error out and be labeled 'Pane is dead'